### PR TITLE
Flycut now doesn't trigger a switch to the discrete GPU on 2011 MBPs and later.

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -42,5 +42,7 @@
 	<array/>
 	<key>UTImportedTypeDeclarations</key>
 	<array/>
+	<key>NSSupportsAutomaticGraphicsSwitching</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
This change stops Flycut from switching to the discrete GPU on 2011
MacBook Pros and later - this helps extend battery life since Flycut is
intended to be running in the background most (if not all) of the time.
