### PR TITLE
Fix Flycut for Emacs 24

### DIFF
--- a/AppController.m
+++ b/AppController.m
@@ -278,7 +278,7 @@
     }
     //9 = "v"
     CGEventRef eventDown = CGEventCreateKeyboardEvent(sourceRef, (CGKeyCode)9, true);
-    CGEventSetFlags(eventDown, kCGEventFlagMaskCommand);
+    CGEventSetFlags(eventDown, kCGEventFlagMaskCommand|0x000008); // some apps want bit set for one of the command keys
     CGEventRef eventUp = CGEventCreateKeyboardEvent(sourceRef, (CGKeyCode)9, false);
     CGEventPost(kCGHIDEventTap, eventDown);
     CGEventPost(kCGHIDEventTap, eventUp);


### PR DESCRIPTION
IMHO this is really an Emacs bug, so feel free to ignore this with impunity;  just wanted to get it available in case anyone else is running into the same problem.

The new Emacs 24 event loop (specifically, Gnu Emacs for Mac -- haven't tried Aquamacs) doesn't properly deal with synthetic keyboard events.  For command-V, for example, it expects that the modifier flags will be set for either for the left or right command key.  If neither is set, then it doesn't deal with the command key properly.  (There may be other programs that also exhibit this behavior).

To reproduce, take Flycut bound to the default Command-shift-V, and then try to paste something.  Emacs 24 will not properly paste.  

Hacky solution is to set one of the modifier flags so that Emacs properly deals with it.  Better long term fix would be to fix Emacs itself, but I don't have a buildable environment for it yet. 
