### PR TITLE
Minor changes to bezel

### DIFF
--- a/AppController.m
+++ b/AppController.m
@@ -261,6 +261,17 @@
 	}
 }
 
+- (void)changeStack
+{
+	if ( [clippingStore jcListCount] > stackPosition ) {
+		[self pasteIndex: stackPosition];
+		[self performSelector:@selector(hideApp) withObject:nil afterDelay:0.2];
+	} else {
+		[self performSelector:@selector(hideApp) withObject:nil afterDelay:0.2];
+	}
+}
+
+
 - (void)pasteIndex:(int) position {
 	[self addClipToPasteboardFromCount:position];
 
@@ -344,9 +355,12 @@
 			case 0x1B:
 				[self hideApp];
 				break;
-			case 0x3: case 0xD: // Enter or Return
+            case 0xD: // Enter or Return
 				[self pasteFromStack];
 				break;
+			case 0x3:
+                [self changeStack];
+                break;
             case 0x2C: // Comma
                 if ( modifiers & NSCommandKeyMask ) {
                     [self showPreferencePanel:nil];


### PR DESCRIPTION
I modified the bezel hotkeys so that Return (fn+Enter) changes the stack position without pasting the text.  This is useful on the command line when you want to pipe the contents of a previous clipboard with pbpaste.

For example, when writing papers I use this command to format it.  This commit makes it possible to change back to the buffer I had copied the markdown text into.

```
pbpaste | pandoc -f markdown -t latex --latex-engine=xelatex --variable fontsize=12pt -s -H preamble --bibliography=bibliography.bib --csl=chicago-note-biblio-no-ibid.csl | xelatex && open -a Skim texput.pdf
```
