### PR TITLE
Bug fix for Issue 36 - "Preferences not saving".

### DIFF
--- a/AppController.m
+++ b/AppController.m
@@ -725,6 +725,8 @@
     } else {
         // Remove clips from store
         [[DBUserDefaults standardUserDefaults] setValue:[NSDictionary dictionary] forKey:@"store"];
+        NSLog(@"Saving preferences on exit");
+        [[DBUserDefaults standardUserDefaults] synchronize];
     }
 	//Unregister our hot key (not required)
 	[[SGHotKeyCenter sharedCenter] unregisterHotKey: mainHotKey];


### PR DESCRIPTION
Hi Gennadiy,
Here's a simple fix for Issue 36.

The problem originated in revision 8 of Jumpcut, which added use of NSUserDefaults without a call to NSUserDefaults's synchronize function on exit.  NSUserDefaults documentation states that synchronize is automatically invoked at periodic intervals but not automatically at exit and thus was unreliable without an explicit call.  The problem was masked by a call to synchronize whenever a clipping was added if save is enabled.

Thanks,
Mark
