### PR TITLE
Save clipping to file

### DIFF
--- a/AppController.h
+++ b/AppController.h
@@ -65,6 +65,7 @@
 -(void) setPBBlockCount:(NSNumber *)newPBBlockCount;
 -(void) hideApp;
 -(void) pasteFromStack;
+-(void) saveFromStack;
 -(void) fakeCommandV;
 -(void) stackUp;
 -(void) stackDown;

--- a/UI/BezelWindow.m
+++ b/UI/BezelWindow.m
@@ -102,6 +102,10 @@ static const float lineHeight = 16;
 
 - (void)setText:(NSString *)newText
 {
+    // The Bezel gets slow when newText is huge.  Probably the retain.
+    // Since we can't see that much of it anyway, trim to 2000 characters.
+    if ([newText length] > 2000)
+        newText = [newText substringToIndex:2000];
 	[newText retain];
 	[bezelText release];
 	bezelText = newText;


### PR DESCRIPTION
Adds the ability to save clippings from the bezel to a file on the Desktop with file naming modeled after the files created by the OS X "Screen Shot" feature (e.g. Desktop/Clipping 2015-05-27 at 9.32.58 PM.txt).

Also improves bezel performance when working with large copy buffers.

I've been frequently transferring 32K-line console outputs from a remote Windows system via RDP and pasting them into files on my Mac where I analyze them as a least-pain way of having to run tests on Windows.  These two changes have saved me hours by streamlining that process.