### PR TITLE
This pull request fixes #45

### DIFF
--- a/AppController.m
+++ b/AppController.m
@@ -305,7 +305,7 @@
                                              backing:NSBackingStoreBuffered
                                                defer:NO
                                           showSource:[[NSUserDefaults standardUserDefaults] boolForKey:@"displayClippingSource"]];
-
+    
     [bezel trueCenter];
     [bezel setDelegate:self];
 }
@@ -1089,7 +1089,9 @@
 - (void)hitMainHotKey:(SGHotKey *)hotKey
 {
 	if ( ! isBezelDisplayed ) {
-		[NSApp activateIgnoringOtherApps:YES];
+        //Do NOT activate the app so focus stays on app the user is interacting with
+        //https://github.com/TermiT/Flycut/issues/45
+		//[NSApp activateIgnoringOtherApps:YES];
 		if ( [[NSUserDefaults standardUserDefaults] boolForKey:@"stickyBezel"] ) {
 			isBezelPinned = YES;
 		}

--- a/AppController.m
+++ b/AppController.m
@@ -305,7 +305,7 @@
                                              backing:NSBackingStoreBuffered
                                                defer:NO
                                           showSource:[[NSUserDefaults standardUserDefaults] boolForKey:@"displayClippingSource"]];
-    
+
     [bezel trueCenter];
     [bezel setDelegate:self];
 }
@@ -1089,8 +1089,8 @@
 - (void)hitMainHotKey:(SGHotKey *)hotKey
 {
 	if ( ! isBezelDisplayed ) {
-        //Do NOT activate the app so focus stays on app the user is interacting with
-        //https://github.com/TermiT/Flycut/issues/45
+		//Do NOT activate the app so focus stays on app the user is interacting with
+		//https://github.com/TermiT/Flycut/issues/45
 		//[NSApp activateIgnoringOtherApps:YES];
 		if ( [[NSUserDefaults standardUserDefaults] boolForKey:@"stickyBezel"] ) {
 			isBezelPinned = YES;

--- a/UI/BezelWindow.h
+++ b/UI/BezelWindow.h
@@ -15,7 +15,7 @@
 #import "RoundRecTextField.h"
 
 
-@interface BezelWindow : NSWindow {
+@interface BezelWindow : NSPanel {
 	// "n of n" text in bezel
 	NSString			*charString; // Slightly misleading, as this can be longer than one character
 	NSString			*title;

--- a/UI/BezelWindow.m
+++ b/UI/BezelWindow.m
@@ -20,13 +20,16 @@ static const float lineHeight = 16;
   				backing:(NSBackingStoreType)bufferingType
 					defer:(BOOL)flag
 			   showSource:(BOOL)showSource {
-    
-	self = [super initWithContentRect:contentRect
-							styleMask:NSBorderlessWindowMask
+
+    self = [super initWithContentRect:contentRect
+							styleMask:NSNonactivatingPanelMask | NSBorderlessWindowMask
 							backing:NSBackingStoreBuffered
 							defer:NO];
 	if ( self )
 	{
+        //set this window to be on top of all other windows
+        [self setLevel:NSScreenSaverWindowLevel];
+
 		[self setOpaque:NO];
 		[self setAlphaValue:1.0];
 		[self setOpaque:NO];

--- a/UI/BezelWindow.m
+++ b/UI/BezelWindow.m
@@ -21,14 +21,14 @@ static const float lineHeight = 16;
 					defer:(BOOL)flag
 			   showSource:(BOOL)showSource {
 
-    self = [super initWithContentRect:contentRect
+	self = [super initWithContentRect:contentRect
 							styleMask:NSNonactivatingPanelMask | NSBorderlessWindowMask
 							backing:NSBackingStoreBuffered
 							defer:NO];
 	if ( self )
 	{
-        //set this window to be on top of all other windows
-        [self setLevel:NSScreenSaverWindowLevel];
+		//set this window to be on top of all other windows
+		[self setLevel:NSScreenSaverWindowLevel];
 
 		[self setOpaque:NO];
 		[self setAlphaValue:1.0];


### PR DESCRIPTION
When showing the bevel we no longer activate flycut keeping the focus on the user's application.  To make the bezel visible above all other windows it was changed to an NSPanel and given the highest level.  

This fixes the issues I was seeing with my multi-monitor setup and should fix others problems as well as we are no longer relying on the OS to give the focus back to the correct window of the application.