### PR TITLE
Make bezel close when it loses focus

### DIFF
--- a/AppController.h
+++ b/AppController.h
@@ -22,7 +22,7 @@
 
 @class SGHotKey;
 
-@interface AppController : NSObject <NSMenuDelegate, NSApplicationDelegate, NSAlertDelegate, FlycutStoreDelegate, FlycutOperatorDelegate> {
+@interface AppController : NSObject <NSMenuDelegate, NSApplicationDelegate, NSAlertDelegate, FlycutStoreDelegate, FlycutOperatorDelegate, BezelWindowDelegate> {
     BezelWindow					*bezel;
 	SGHotKey					*mainHotKey;
 	IBOutlet SRRecorderControl	*mainRecorder;
@@ -97,6 +97,7 @@
 -(void) processBezelKeyDown:(NSEvent *)theEvent;
 -(void) processBezelMouseEvents:(NSEvent *)theEvent;
 -(void) metaKeysReleased;
+-(void) windowDidResignKey:(NSNotification *)notification;
 
 // Menu related
 -(void) updateMenu;

--- a/AppController.m
+++ b/AppController.m
@@ -758,6 +758,12 @@
 	}
 }
 
+- (void)windowDidResignKey:(NSNotification *)notification {
+	if ( isBezelPinned ) {
+		[self hideApp];
+	}
+}
+
 -(void)fakeKey:(NSNumber*) keyCode withCommandFlag:(BOOL) setFlag
 	/*" +fakeKey synthesizes keyboard events. "*/
 {     
@@ -1059,8 +1065,8 @@ didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {
 
 -(void)hideApp
 {
-	[self hideBezel];
 	isBezelPinned = NO;
+	[self hideBezel];
 	[NSApp hide:self];
 }
 

--- a/UI/BezelWindow.h
+++ b/UI/BezelWindow.h
@@ -14,6 +14,13 @@
 #import "RoundRecBezierPath.h"
 #import "RoundRecTextField.h"
 
+@protocol BezelWindowDelegate <NSWindowDelegate>
+
+-(void)processBezelKeyDown:(NSEvent *)theEvent;
+-(void)processBezelMouseEvents:(NSEvent *)theEvent;
+-(void)metaKeysReleased;
+
+@end
 
 @interface BezelWindow : NSPanel {
 	// "n of n" text in bezel
@@ -33,7 +40,7 @@
 	RoundRecTextField	*textField;
 	RoundRecTextField	*charField;
 	NSImageView			*iconView;
-	id					delegate;
+	id<BezelWindowDelegate>	delegate;
     Boolean             color;
 }
 
@@ -57,7 +64,7 @@
 - (void)setDate:(NSString *)newDate;
 - (void)setSourceIcon:(NSImage *)newSourceIcon;
 
-- (id)delegate;
-- (void)setDelegate:(id)newDelegate;
+- (id<BezelWindowDelegate>)delegate;
+- (void)setDelegate:(id<BezelWindowDelegate>)newDelegate;
 
 @end

--- a/UI/BezelWindow.m
+++ b/UI/BezelWindow.m
@@ -365,12 +365,13 @@ static const float lineHeight = 16;
 	}
 }
 		
-- (id)delegate {
+- (id<BezelWindowDelegate>)delegate {
     return delegate;
 }
 
-- (void)setDelegate:(id)newDelegate {
+- (void)setDelegate:(id<BezelWindowDelegate>)newDelegate {
     delegate = newDelegate;
+	super.delegate = newDelegate;
 }
 
 @end


### PR DESCRIPTION
**Problem:**
The bezel doesn't provide any UI indication when it loses focus and this no longer responds to input. This ranges anywhere from being klunky to being a bug. Users have reported that they believed Flycut to have hung when encountering this. e.g. #198 

**Solution:**
Receive and handle `windowDidResignKey:` message.

**Changes:**
* AppController.h - Implement delegate and handle `windowDidResignKey:` message.
* AppController.m - Implement handling of `windowDidResignKey:` message.
* UI/BezelWindow.h - Define and use new delegate.
* UI/BezelWindow.m - Use new delegate and assign `super`'s delegate.

**Notes:**
Defines a protocol for the BezelWindow's delegate, which had previously just been a blind id delegate and makes the new delegate inherit from NSWindowDelegate so that AppController can receive windowDidResignKey: to indicate when focus is lost and immediately close the bezel.

Somebody probably has a use case for keeping the bezel open, but since they can just use the hotkey to reopen the bezel to where they left it this seems like an insignificant impact on them. I'd figure more people found the prior behavior to be annoying, so this should be a net win for Flycut.

Thanks!