### PR TITLE
Fix "Launch Flycut on login" not working for builds without SANDBOXING defined

### DIFF
--- a/Flycut.entitlements
+++ b/Flycut.entitlements
@@ -16,5 +16,10 @@
 	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
+
+	<key>com.apple.security.automation.apple-events</key>
+	<true/>
+	<key>com.apple.security.temporary-exception.apple-events</key>
+	<string>com.apple.systemevents</string>
 </dict>
 </plist>

--- a/FlycutDebug.entitlements
+++ b/FlycutDebug.entitlements
@@ -16,5 +16,10 @@
 	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
+
+	<key>com.apple.security.automation.apple-events</key>
+	<true/>
+	<key>com.apple.security.temporary-exception.apple-events</key>
+	<string>com.apple.systemevents</string>
 </dict>
 </plist>

--- a/Info.plist
+++ b/Info.plist
@@ -27,7 +27,7 @@
 	<key>LSUIElement</key>
 	<string>1</string>
 	<key>NSAppleEventsUsageDescription</key>
-	<string>Flycut needs this permission to be able to paste text into other applications</string>
+	<string>Flycut needs this permission to be able to paste text into other applications, and add itself to Login Items to be launched on login.</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>(c) General Arcade, 2011-2020</string>
 	<key>NSMainNibFile</key>

--- a/configureAppSandboxing.sh
+++ b/configureAppSandboxing.sh
@@ -40,5 +40,30 @@ do
 	done
 done
 
+for entitlements in $(git grep -l -e ">com.apple.security.automation.apple-events<" -- '*.entitlements')
+do
+	if [ "$defineSandboxing" == "false" ]
+	then
+		/usr/libexec/PlistBuddy -c "Set :com.apple.security.automation.apple-events true" "$entitlements"
+	else
+		/usr/libexec/PlistBuddy -c "Delete :com.apple.security.automation.apple-events" "$entitlements"
+	fi
+
+	git add "$entitlements"
+done
+
+
+for entitlements in $(git grep -l -e ">com.apple.security.temporary-exception.apple-events<" -- '*.entitlements')
+do
+	if [ "$appSandboxing" == "true" ] && [ "$defineSandboxing" == "false" ]
+	then
+		/usr/libexec/PlistBuddy -c "Set :com.apple.security.temporary-exception.apple-events com.apple.systemevents" "$entitlements"
+	else
+		/usr/libexec/PlistBuddy -c "Delete :com.apple.security.temporary-exception.apple-events" "$entitlements"
+	fi
+
+	git add "$entitlements"
+done
+
 git commit -m "App Sandbox $(if [ "$appSandboxing" == "true" ] ; then echo "ON" ; else echo "OFF" ; fi)$(if [ "$defineSandboxing" == "true" ] ; then echo " with define" ; fi)"
 

--- a/configureAppSandboxing.sh
+++ b/configureAppSandboxing.sh
@@ -17,7 +17,7 @@ then
 	defineSandboxing=true
 else
 	echo "Run with parameter YES or NO to enable or disable app sandboxing."
-	echo "Or with parameter SANDBOXING to enable or app sandboxing and define SANDBOXING"
+	echo "Or with parameter SANDBOXING to enable app sandboxing and define SANDBOXING"
 	echo "  in the prefix header."
 	exit -1
 fi


### PR DESCRIPTION
Fix https://github.com/TermiT/Flycut/issues/206.
Fix https://github.com/TermiT/Flycut/issues/236.

I've tested all three scenarios and all of them worked.
  - `./configureAppSandboxing.sh YES`
  - `./configureAppSandboxing.sh NO`
  - `./configureAppSandboxing.sh SANDBOXING`

In the first two scenarios, Flycut was able to add itself to Login Items and was launched on subsequent logins.
In the last scenario, Flycut registered FlycutHelper to start on login and was launched on subsequent logins.

I've also verified that for both v1.9.6 binaries distributed on App Store and on GitHub, "Launch Flycut on login" option doesn't work and Flycut isn't launched on login.

It would be great if we could release a new version on both channels with this fix. But since Apple might not grant these permissions for versions submitted to the App Store, it would useful to at least apply this fix to future GitHub releases.